### PR TITLE
Remove reference to implication constraints

### DIFF
--- a/content/ideas/ghc-type-system.md
+++ b/content/ideas/ghc-type-system.md
@@ -9,7 +9,7 @@ be found in
 [one](https://github.com/ghc-proposals/ghc-proposals/pull/54)
 [of](https://github.com/ghc-proposals/ghc-proposals/pull/81) [several](https://github.com/ghc-proposals/ghc-proposals/pull/83)
 [related](https://github.com/ghc-proposals/ghc-proposals/pull/80)
-[proposals](https://github.com/ghc-proposals/ghc-proposals/pull/99) [posted](https://github.com/ghc-proposals/ghc-proposals/pull/102) [recently](https://github.com/ghc-proposals/ghc-proposals/pull/103). Ideas beyond those proposals includes merging
+[proposals](https://github.com/ghc-proposals/ghc-proposals/pull/99) [posted](https://github.com/ghc-proposals/ghc-proposals/pull/102) [recently](https://github.com/ghc-proposals/ghc-proposals/pull/103). Ideas beyond those proposals include merging
 the parsers for types and terms, as well as to sort out The Namespace Problem (GHC allows declarations like `data T = T`. How would that
 work in a dependently typed language where terms are not syntactically distinct from types?). A student more versed in type theory
 (e.g., having experience with [Types and Programming Languages](https://www.cis.upenn.edu/~bcpierce/tapl/), among [other](http://www.cs.cmu.edu/~rwh/pfpl.html) introductions) might even attempt implementing a dependently typed Core replacement. If you like, you can

--- a/content/ideas/ghc-type-system.md
+++ b/content/ideas/ghc-type-system.md
@@ -1,26 +1,24 @@
 ---
-title: Implement quantified contexts (or other type system goodies)
+title: Implement aspects of Dependent Haskell
 ---
 
-In last year's Haskell Symposium, Gert-Jan Bottu et al. [described](http://homepages.inf.ed.ac.uk/wadler/papers/quantcc/quantcc.pdf)
-a plan for *quantified contexts*, where a user could write a type like `forall h. (forall f. Functor f => Functor (h f)) => h Maybe Int -> h [] Int`. The paper linked above has more realistic examples. The key is that a constraint is actually an implication.
+The design of GHC/Haskell has been steadily marching toward support for dependent types for a long time, debatably starting with the addition of `-XFunctionalDependencies`, as proposed in 2000. With the `-XTypeInType` extension in GHC 8.0 (2016), we're as close as ever. However, much more work remains to be done. This Summer of Haskell idea is to slice off a chunk of that work and implement it!
 
-The idea as described in that paper would not jibe well with GHC, as the paper's specification requires backtracking in order to implement. However, a small tweak to what's described in the paper would no longer need backtracking and should be relatively straightforward to implement. The project would be to finish specifying and then implement this proposal.
-
-It will have significant real-world impact, fixing long-standing GHC bug [#2256](https://ghc.haskell.org/trac/ghc/ticket/2256) and allowing `join` to be added to the `Monad` typeclass, among other benefits. (The route from this proposal to `join` is a bit long and goes via roles, but trust me here that this proposal is the blocker.)
-
-Beyond just quantified contexts, I'm happy to mentor students who wish to hack on GHC's type system.
-In particular, advances toward dependent
-types are strongly encouraged. This might include implementing [one](https://github.com/ghc-proposals/ghc-proposals/pull/54)
+Precisely *which* chunk(s) are up to you, the proposer of the project. Good starting places if you're looking for inspiration can
+be found in
+[one](https://github.com/ghc-proposals/ghc-proposals/pull/54)
 [of](https://github.com/ghc-proposals/ghc-proposals/pull/81) [several](https://github.com/ghc-proposals/ghc-proposals/pull/83)
-[proposals](https://github.com/ghc-proposals/ghc-proposals/pull/99) posted recently. Ideas beyond those proposals includes merging
+[related](https://github.com/ghc-proposals/ghc-proposals/pull/80)
+[proposals](https://github.com/ghc-proposals/ghc-proposals/pull/99) [posted](https://github.com/ghc-proposals/ghc-proposals/pull/102) [recently](https://github.com/ghc-proposals/ghc-proposals/pull/103). Ideas beyond those proposals includes merging
 the parsers for types and terms, as well as to sort out The Namespace Problem (GHC allows declarations like `data T = T`. How would that
-work in a dependently typed language where terms are not syntactically distinct from types?). If you like, you can
+work in a dependently typed language where terms are not syntactically distinct from types?). A student more versed in type theory
+(e.g., having experience with [Types and Programming Languages](https://www.cis.upenn.edu/~bcpierce/tapl/), among [other](http://www.cs.cmu.edu/~rwh/pfpl.html) introductions) might even attempt implementing a dependently typed Core replacement. If you like, you can
 see [Richard Eisenberg's thesis](https://repository.brynmawr.edu/cgi/viewcontent.cgi?article=1074&context=compsci_pubs) for
-inspiration.
+inspiration. That thesis aims to describe both the surface language and Core language for Dependent Haskell.
 
 If you can relocate to the Philadelphia, PA, USA, area for the summer, there will be office space you can use, and you'll
-be able to work in a space with several other people hacking on GHC. Remote mentorship is also possible, of course.
+be able to work in a space with several other people hacking on GHC. Unfortunately, there is no extra funding to support
+this relocation. Remote mentorship is also possible, of course.
 
 **Mentor**: [Richard Eisenberg](mailto:rae@cs.brynmawr.edu) (feel free to email to discuss ideas for your proposal)
 


### PR DESCRIPTION
This is an update to the type-system-hacking idea, as Simon has already implemented implication constraints in a rainy weekend. This update blurs the focus of the idea, but I think the broader aim may allow proposers to find an aspect they care more about.