### PR TITLE
Update cabal instructions & setup CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+# simplified haskell-ci Travis setup
+# see also https://github.com/haskell-CI/haskell-ci
+
+language: haskell
+
+cache:
+  directories:
+   - $HOME/.cabal/store
+
+cabal: 2.4
+ghc:
+  - "8.6.3"
+  - "8.4.4"
+  - "8.2.2"
+  - "8.0.2"
+  - "7.10.3"
+
+install:
+ - cabal --version
+ - ghc --version
+
+script:
+ - cabal v2-update
+ - cabal v2-build exes
+ - cabal check
+ - cabal v2-run exe:summer-of-haskell -- check --internal-links

--- a/README.md
+++ b/README.md
@@ -4,7 +4,16 @@ This is the source code for the summer of Haskell website.
 
 ## How to build this website
 
-### Using cabal
+### Using `cabal`
+
+#### Modern method (Cabal 2.4 and newer)
+
+This is the recommended method and at time of writing is known
+to work with GHC 7.10.3 through GHC 8.6.3.
+
+    cabal v2-run exes -- preview
+
+#### Legacy method
 
     cabal install --only-dependencies
     cabal build

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,2 @@
+-- see https://www.haskell.org/cabal/users-guide/nix-local-build-overview.html
+packages: .

--- a/summer-of-haskell.cabal
+++ b/summer-of-haskell.cabal
@@ -1,7 +1,7 @@
 Name:                summer-of-haskell
 Version:             0.1.0.0
 Synopsis:            Website for the Summer of Haskell
-Description:         Website for the Summer of Haskell
+Description:         Website for the Summer of Haskell.
 License:             BSD3
 License-file:        LICENSE
 Author:              Jasper Van der Jeugt <m@jaspervdj.be>
@@ -11,6 +11,10 @@ Category:            Web
 Build-type:          Simple
 Cabal-version:       >=1.10
 
+source-repository head
+  type: git
+  location: https://github.com/haskell-org/summer-of-haskell.git
+
 Executable summer-of-haskell
   Main-is:             Main.hs
   Ghc-options:         -Wall
@@ -18,7 +22,7 @@ Executable summer-of-haskell
   Default-language:    Haskell2010
 
   Build-depends:
-    base         >= 4    && < 5,
+    base         >= 4.8  && < 5,
     filepath     >= 1.4  && < 1.5,
     hakyll       >= 4.10 && < 4.13,
     pandoc       >= 2.0  && < 2.6,


### PR DESCRIPTION
NB: This repo needs to be enabled on https://travis-ci.org/ before the `.travis.yml` file has any effect.