### PR TITLE
Update dead link

### DIFF
--- a/content/ideas.html
+++ b/content/ideas.html
@@ -59,7 +59,7 @@
   </li>
   <li>
     Some general tips on writing a proposal are discussed
-    <a href="http://write.flossmanuals.net/gsocstudentguide/writing-a-proposal/">here</a>.
+    <a href="https://google.github.io/gsocguides/student/writing-a-proposal">here</a>.
   </li>
 </ul>
 


### PR DESCRIPTION
Currently the link redirects to http://archive.flossmanuals.net/index.html.

They moved the guide to github. See http://archive.flossmanuals.net/gsocstudentguide/index.html.