### PR TITLE
redirect irc to something current

### DIFF
--- a/content/contact.md
+++ b/content/contact.md
@@ -9,5 +9,5 @@ The Summer of Haskell is organised by the
 can reach us by sending an email to `committee [AT] haskell.org`.
 Alternatively, you can contact `m [AT] jaspervdj.be` directly.
 
-There is also an IRC channel called `#haskell-gsoc` on
-[freenode](https://freenode.net/) where you can ask for help.
+There is also an IRC channel called `#haskell` on
+[libera](https://https://libera.chat//) where you can ask for help.


### PR DESCRIPTION
freenode is dead by now, and on libera there's really no haskell gsoc channel afaik, but the main one is still a good place for people to show up and get advice.