### PR TITLE
Communicate that Haskell was not accepted

### DIFF
--- a/content/ideas.html
+++ b/content/ideas.html
@@ -1,3 +1,9 @@
+<p>
+  <strong>Update</strong>: Sadly, Haskell was not selected to take part in GSoC
+  2023. On the bright side, we are intending to run an independent <i>Haskell
+  Summer of Code</i> program instead. Details are forthcoming.
+</p>
+
 <h1>GSoC 2023 Ideas</h1>
 
 <p>


### PR DESCRIPTION
Adds a note indicating that we were not accepted for GSoC 2023 and our intent to run an independent program.