### PR TITLE
Fix the eligibility guidelines link

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -28,7 +28,10 @@ that you can select from, or you may also propose an idea of your own if
 you'd prefer.
 
 Our guidelines around contributor eligibility as well as the stipend will
-mirror those of <i>Google Summer of Code</i>. See [here](https://developers.google.com/open-source/gsoc/help/student-stipends)
+mirror those of <i>Google Summer of Code</i>. See
+[here](https://developers.google.com/open-source/gsoc/faq#what_are_the_eligibility_requirements_for_participation)
+and
+[here](https://developers.google.com/open-source/gsoc/faq#are_participants_from_ukraine_russia_or_belarus_allowed_to_participate_in_gsoc_2023)
 for eligibility guidelines, and [here](/stipend.html) for stipend information.
 Please be sure to review the eligibility guidelines before you start working on
 a proposal.


### PR DESCRIPTION
The eligibility guidelines link mistakenly pointed to the stipend information.