### PR TITLE
Add proposal for xeus-haskell

### DIFF
--- a/content/ideas/xeus-haskell-ghc-wasm.md
+++ b/content/ideas/xeus-haskell-ghc-wasm.md
@@ -1,0 +1,23 @@
+---
+title: xeus-haskell: GHC/Wasm Backend Integration Prototype
+---
+
+**Project Context**
+As part of the **jupyter-xeus** organization, `xeus-haskell` aims to provide a "run anywhere" Haskell environment. While the current MicroHs backend is optimized for size and speed in the browser, a GHC/Wasm-backed execution mode would unlock the full power of the Haskell ecosystem (Hackage). This research-intensive engineering project focuses on bridging the `xeus` C++ framework with the emerging GHC WebAssembly backend to support more complex production workflows in the browser.
+
+
+
+**Goals**
+* **Proof of Concept:** Extend the C++ bridge (`mhs_repl.cpp`) to route execution requests to a GHC/Wasm-compiled runtime.
+* **Runtime Optimization:** Document and mitigate browser-specific constraints, such as bundle size, startup latency, and filesystem access.
+* **Backend Interoperability:** Define a clean architecture to allow users to switch between the lightweight MicroHs and the full-featured GHC/Wasm backends.
+
+**Prerequisites**
+* **Language:** Advanced Haskell (GHC extensions, FFI, and compiler internals).
+* **Systems:** Proficiency in C++ (standard 14 or higher) for kernel-level integration.
+* **WebAssembly:** Familiarity with Wasm runtimes, Emscripten, or the WASI standard.
+* **Bonus:** Experience with GHC's Javascript/Wasm backends or `xeus` core development.
+
+**Mentors:** [Masaya Taniguchi](https://github.com/tani)
+**Project Size:** 350h (Large)
+**Difficulty:** Hard

--- a/content/ideas/xeus-haskell-libraries.md
+++ b/content/ideas/xeus-haskell-libraries.md
@@ -1,0 +1,22 @@
+---
+title: xeus-haskell: Library Expansion and Packaging for MicroHs
+---
+
+**Project Context**
+`xeus-haskell` is an official Jupyter kernel for Haskell, maintained under the **jupyter-xeus** organization. It is based on **xeus**, the native C++ implementation of the Jupyter protocol. By leveraging the MicroHs compiler, `xeus-haskell` provides a unique experience that runs both natively (Linux, macOS, Windows) and directly in the browser via WebAssembly (JupyterLite). This project aims to transition the kernel from a proof-of-concept to a robust tool for data science and education by expanding its library ecosystem.
+
+**Goals**
+* **Feasibility Study:** Identify high-impact libraries (Haskell 2010 subset) that can be realistically compiled under MicroHs.
+* **Library Expansion:** Port and validate a priority set of libraries (e.g., `containers`, `mtl`, `bytestring`, `aeson`) for the MicroHs backend.
+* **Automated Packaging:** Integrate with `pixi`, `conda-forge`, and `emscripten-forge` to automate CI/CD pipelines for both native and Wasm targets.
+* **Educational Content:** Develop "Getting Started" notebooks that demonstrate these libraries in a zero-install JupyterLite environment.
+
+**Prerequisites**
+* **Language:** Strong proficiency in Haskell (especially Haskell 2010 standards).
+* **Tooling:** Familiarity with modern package management (Conda / Pixi).
+* **Systems:** Basic understanding of CI/CD workflows (GitHub Actions).
+* **Bonus:** Previous experience with the MicroHs compiler or contributing to `conda-forge`.
+
+**Mentors:** [Masaya Taniguchi](https://github.com/tani)
+**Project Size:** 175h (Medium) / 350h (Large)
+**Difficulty:** Medium

--- a/content/ideas/xeus-haskell-performance.md
+++ b/content/ideas/xeus-haskell-performance.md
@@ -1,0 +1,21 @@
+---
+title: xeus-haskell: Precompilation and Caching for Instant Startup
+---
+
+**Project Context**
+A key value proposition of the **jupyter-xeus** project `xeus-haskell` is its zero-install accessibility via JupyterLite. However, loading libraries in a web environment can introduce latency. This project focuses on developer ergonomics and performance by implementing a precompilation and caching strategy. The goal is to ensure that when a student or researcher opens a Haskell notebook, the environment is ready for execution instantly.
+
+**Goals**
+* **Artifact Caching:** Develop a mechanism to precompile MicroHs core modules and third-party libraries into portable, cacheable artifacts.
+* **Pipeline Integration:** Automate cache generation within the `emscripten-forge` and `conda-forge` packaging workflows.
+* **Performance Benchmarking:** Establish quantitative metrics to measure cold-start vs. warm-start latency and ensure a smooth user experience.
+
+**Prerequisites**
+* **Language:** Comfortable reading Haskell and C++ code.
+* **Tooling:** Experience with build systems (Make, CMake) and shell scripting.
+* **DevOps:** Familiarity with GitHub Actions or other automation platforms.
+* **Bonus:** Knowledge of compiler optimization techniques or file system caching strategies.
+
+**Mentors:** [Masaya Taniguchi](https://github.com/tani)
+**Project Size:** 175h (Medium)
+**Difficulty:** Medium

--- a/content/ideas/xeus-haskell-widgets.md
+++ b/content/ideas/xeus-haskell-widgets.md
@@ -1,0 +1,23 @@
+---
+title: xeus-haskell: Interactive Widgets for Haskell Notebooks
+---
+
+**Project Context**
+Developed under the **jupyter-xeus** umbrella, `xeus-haskell` already supports rich display outputs (HTML, LaTeX, Markdown). This project will implement **ipywidgets** compatibility, enabling truly interactive notebooks. By adding support for the Jupyter "comm" protocol, you will allow users to create Haskell-driven GUI elements—such as sliders, buttons, and dropdowns—that can manipulate data visualizations in real-time.
+
+
+
+**Goals**
+* **Protocol Implementation:** Implement Jupyter "comm" messages for state synchronization between the Haskell kernel and the browser frontend.
+* **Widget Library:** Build a developer-friendly Haskell DSL/library to instantiate and control standard widgets (Slider, Button, Text).
+* **Interactive Demos:** Create curated notebooks demonstrating the power of interactive widgets combined with the `Display` typeclass for teaching and data exploration.
+
+**Prerequisites**
+* **Language:** Solid Haskell skills, specifically in state management and handling side effects.
+* **Protocol:** Understanding of JSON-based network protocols or the Jupyter messaging spec.
+* **Frontend:** Basic knowledge of HTML/CSS for widget rendering and styling.
+* **Bonus:** Experience using `ipywidgets` in Python or a similar interactive system in another language.
+
+**Mentors:** [Masaya Taniguchi](https://github.com/tani)
+**Project Size:** 175h (Medium) / 350h (Large)
+**Difficulty:** Medium


### PR DESCRIPTION
## Description
This PR adds GSoC 2026 project ideas for **xeus-haskell**.

I am submitting these as a maintainer of the `xeus-haskell` project within the **jupyter-xeus** organization, following the recommendation from **mchav** (@mchav). 

`xeus-haskell` provides a native Jupyter kernel for Haskell using the `xeus` framework, with a specific focus on cross-platform accessibility and browser-based execution via WebAssembly (JupyterLite).

## Proposed Project Tracks
- **Track A (Libraries):** Expanding the MicroHs-usable library set for "batteries-included" notebooks.
- **Track B (GHC/Wasm):** Prototyping a GHC-backed execution mode in the browser.
- **Track C (Widgets):** Adding `ipywidgets` support via the Jupyter `comm` protocol.
- **Track D (Performance):** Implementing precompilation and caching to reduce startup latency.